### PR TITLE
Fixes for null stack trace & peer jasmine-core

### DIFF
--- a/tasks/lib/jasmine.reporter.js
+++ b/tasks/lib/jasmine.reporter.js
@@ -35,7 +35,10 @@ module.exports = (function () {
     }
 
     function filterStack(stack) {
-        var jasmineCorePath = '/node_modules/jasmine/node_modules/jasmine-core/';
+        if(!stack) {
+            return stack;
+        }
+        var jasmineCorePath = '/node_modules/jasmine-core';
         var filteredStack = stack.split('\n')
             .filter(function (stackLine) {
                 return stackLine.indexOf(jasmineCorePath) === -1;


### PR DESCRIPTION
Thanks for a great plugin - so much better than the `grunt-jasmine-node` mess I've been using for a while.

When I'm using this plugin in a project that also uses `karma-jasmine` (for client-side testing), since `karma-jasmine` has a `peerDependency` on `jasmine-core`, my `node_modules` folder structure ends up as follows:

```
grunt-jasmine-nodejs/
  node_modules/
    jasmine/
      node_modules/
        exit/
        glob/
jasmine-core/
karma-jasmine/
```

i.e. the `jasmine-core` library is installed at the top level of the `node_modules` tree.

This means that the `jasmine-core` path is different to the one hard-coded in the task, and so any stack traces contain all the extra jasmine gubbins (see below). This PR relaxes the matcher in the `specFilter` to include this scenario, and also handles cases where an error is thrown without a stack trace (e.g. `throw 'error'`) in a spec.

```
Executing specs...

 ✕ 

Failed Specs:

1) Request Model should be so
  Message:
    Expected 2 to be array.
  Stack:
    Error: Expected 2 to be array.
      at stack (/home/fiznool/Code/projects/flowxo/dev/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1455:17)
      at buildExpectationResult (/home/fiznool/Code/projects/flowxo/dev/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1425:14)
      at Spec.Env.expectationResultFactory (/home/fiznool/Code/projects/flowxo/dev/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:572:18)
      at Spec.addExpectationResult (/home/fiznool/Code/projects/flowxo/dev/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:321:34)
      at Expectation.addExpectationResult (/home/fiznool/Code/projects/flowxo/dev/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:516:21)
      at Expectation.toBeArray (/home/fiznool/Code/projects/flowxo/dev/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1379:12)
      at Object.<anonymous> (/home/fiznool/Code/projects/flowxo/dev/test/server/unit/models/workflow/request.model.spec.js:37:17)
      at attemptSync (/home/fiznool/Code/projects/flowxo/dev/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1741:24)
      at QueueRunner.run (/home/fiznool/Code/projects/flowxo/dev/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1729:9)
      at /home/fiznool/Code/projects/flowxo/dev/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1753:16
      at Immediate.<anonymous> (/home/fiznool/Code/projects/flowxo/dev/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1697:9)
      at Immediate._onImmediate (/home/fiznool/Code/projects/flowxo/dev/node_modules/mongoose/node_modules/mquery/lib/utils.js:137:16)
      at processImmediate [as _immediateCallback] (timers.js:358:17)



0 suites, 1 spec, 1 assert, 1 failure
Finished in 0.492 seconds
```
