### PR TITLE
Windows-friendly filterStack

### DIFF
--- a/tasks/lib/console.reporter.js
+++ b/tasks/lib/console.reporter.js
@@ -63,7 +63,8 @@ module.exports = (function () {
 
     function filterStack(stack) {
         if (!stack) { return stack; }
-        var jasmineCorePath = '/node_modules/jasmine-core';
+        var sep = isWindows ? '\\' : '/';
+        var jasmineCorePath = sep+'node_modules'+sep+'jasmine-core';
         var filteredStack = String(stack).split('\n')
             .filter(function (stackLine) {
                 return stackLine.indexOf(jasmineCorePath) === -1;


### PR DESCRIPTION
Due to the hard-coded FS separator, the filterStack did not work on Windows. The fix is simple : check the OS to choose the appropriate separator.
