### PR TITLE
Don't use clearLine if stdout is not a tty. Fixes #20.

### DIFF
--- a/tasks/lib/console.reporter.js
+++ b/tasks/lib/console.reporter.js
@@ -356,6 +356,10 @@ module.exports = (function () {
                 print.newLine();
             },
             clearLine: function (num) {
+                if (!process.stdout.isTTY) {
+                    return;
+                }
+
                 num = num === undefined
                     ? 1 : (num < 1 ? 1 : num);
                 var i;


### PR DESCRIPTION
This is a possible fix to #20. I'm not sure if this is how you would fix this, and I'm totally cool if you reject this.
