### PR TITLE
Added unloadHelpers function to clear cache

### DIFF
--- a/tasks/jasmine.task.js
+++ b/tasks/jasmine.task.js
@@ -83,6 +83,7 @@ module.exports = function (grunt) {
                 taskComplete(passed);
                 cc = 0;
             }
+            jasmineRunner.unloadHelpers(helperFiles);
         }
 
         // Extends default console reporter options

--- a/tasks/lib/jasmine.runner.js
+++ b/tasks/lib/jasmine.runner.js
@@ -21,6 +21,12 @@ module.exports = (function () {
         });
     }
 
+    function unloadFiles(files) {
+        files.forEach(function (file) {
+            delete require.cache[file];
+        });
+    }
+
     //----------------------------
     //  CLASS: JasmineRunner
     //----------------------------
@@ -82,6 +88,8 @@ module.exports = (function () {
     JasmineRunner.prototype.addMatchers = function (matchers) {
         this.jasmine.Expectation.addMatchers(matchers);
     };
+
+    JasmineRunner.prototype.unloadHelpers = unloadFiles;
 
     JasmineRunner.prototype.loadHelpers = requireFiles;
 


### PR DESCRIPTION
When loading the same helper between executions of jasmine tasks, the
helper file does not get evaluated twice, this means that the helper's
aren't available after the first jasmine task.

I added a function to delete files from the require cache, forcing them
to be reloaded when required a second time, and have the task unload all
of the helpers onComplete
