### PR TITLE
Ability to filter tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ _The `--verbose` option will additionally output list of enabled reporters, spec
 
 Task targets, files and options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
 
+The `--filter` option will filter the sepc files by their **file names** that match the filter.
+```js
+grunt jasmine_nodejs --filter=foo,bar
+```
+
 ### Options
 
 #### specNameSuffix


### PR DESCRIPTION
[`grunt-contrib-jasmine`](https://github.com/gruntjs/grunt-contrib-jasmine) lets the user filter the tests they want to run. Working with people using this package, they would like _(if not expect)_ the ability here.

I used the [`specFilter`](https://github.com/gruntjs/grunt-contrib-jasmine/blob/master/tasks/lib/jasmine.js#L137-L173) function from `grunt-contrib-jasmine` and added the filter option to the task.
